### PR TITLE
抽出适用于PC端的Request Interceptor

### DIFF
--- a/src/common/use_error_interceptor.js
+++ b/src/common/use_error_interceptor.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { RequestInterceptor } from 'gm-util'
+import { Tip } from 'react-gm'
+
+const useErrorInterceptor = () => {
+  const showMsg = (shower, msgs) => {
+    shower({
+      children: msgs.map((msg, i) => <div key={i}> {msg} </div>),
+      time: 0 // 不消失
+    })
+  }
+  const errorInterceptor = {
+    response (json, config) {
+      if (!config.sucCode.includes(json.code)) {
+        // 业务错误
+        let msg = [json.msg || '未知的错误', config.url]
+        showMsg(Tip.warning.bind(Tip), msg)
+      }
+      return json
+    },
+    responseError (reason, config) {
+      // reason 两种
+      // 1. http错误 502 Bad Gateway 等
+      // 2. 连接超时 TypeError Failed to fetch 等网络问题
+      let msg = [reason + '', config.url]
+      showMsg(Tip.danger.bind(Tip), msg)
+    }
+  }
+  RequestInterceptor.add(errorInterceptor)
+}
+export default useErrorInterceptor

--- a/src/common/use_progress_interceptor.js
+++ b/src/common/use_progress_interceptor.js
@@ -1,0 +1,19 @@
+import { RequestInterceptor } from 'gm-util'
+import { NProgress } from 'react-gm'
+
+const useProgressInterceptor = () => {
+  const progressInterceptor = {
+    request () {
+      NProgress.start()
+    },
+    response () {
+      NProgress.done()
+    },
+    responseError () {
+      NProgress.done()
+    }
+  }
+  RequestInterceptor.add(progressInterceptor)
+}
+
+export default useProgressInterceptor


### PR DESCRIPTION
1. 显示请求进度条
2. 统一的响应错误处理。http和网络错误，使用`Tip.danger`显示，业务错误使用`Tip.warning`显示。两者都需要用户点击才关闭