### PR TITLE
报错提示去掉 url

### DIFF
--- a/src/common/use_error_interceptor.js
+++ b/src/common/use_error_interceptor.js
@@ -6,14 +6,14 @@ const useErrorInterceptor = () => {
   const showMsg = (shower, msgs) => {
     shower({
       children: msgs.map((msg, i) => <div key={i}> {msg} </div>),
-      time: 0 // 不消失
+      time: 5000
     })
   }
   const errorInterceptor = {
     response (json, config) {
       if (!config.sucCode.includes(json.code)) {
         // 业务错误
-        let msg = [json.msg || '未知的错误', config.url]
+        let msg = [json.msg || '未知的错误']
         showMsg(Tip.warning.bind(Tip), msg)
       }
       return json
@@ -22,7 +22,7 @@ const useErrorInterceptor = () => {
       // reason 两种
       // 1. http错误 502 Bad Gateway 等
       // 2. 连接超时 TypeError Failed to fetch 等网络问题
-      let msg = [reason + '', config.url]
+      let msg = [reason + '']
       showMsg(Tip.danger.bind(Tip), msg)
     }
   }


### PR DESCRIPTION
提示带上接口 `url` 本来是想在发生系统错误时好排查问题。但是后端现在返回的 `code` 没有区分系统错误和业务错误,导致很多业务错误提示都会带上 `url` 对用户而言不友好, 所以干掉。